### PR TITLE
Add navigation and login pages

### DIFF
--- a/SintesisEstrategica/settings.py
+++ b/SintesisEstrategica/settings.py
@@ -133,3 +133,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+LOGIN_REDIRECT_URL = 'home'
+LOGOUT_REDIRECT_URL = 'home'

--- a/SintesisEstrategica/urls.py
+++ b/SintesisEstrategica/urls.py
@@ -16,8 +16,11 @@ Incluir otra configuración de URLs
 """
 from django.contrib import admin
 from django.urls import path, include
+from observatorio import views as observatorio_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/', include('django.contrib.auth.urls')),
+    path('accounts/signup/', observatorio_views.signup, name='signup'),
     path('', include('observatorio.urls')),  # Rutas de la App
 ]

--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
 from .models import Categoria, Informe, ConsultaUsuario, Suscriptor
 
 class CategoriaForm(forms.ModelForm):
@@ -40,5 +42,19 @@ class ConsultaUsuarioForm(forms.ModelForm):
     class Meta:
         model = ConsultaUsuario
         fields = '__all__'
+
+
+class CustomUserCreationForm(UserCreationForm):
+    documento = forms.CharField(max_length=50, label="Número de documento")
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = (
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "documento",
+        )
 
 

--- a/observatorio/models.py
+++ b/observatorio/models.py
@@ -43,3 +43,13 @@ class Suscriptor(models.Model):
     def __str__(self):
         return f"{self.nombre} {self.apellido} ({self.email})"
 
+
+class PerfilUsuario(models.Model):
+    """Datos adicionales para los usuarios registrados."""
+
+    user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
+    documento = models.CharField(max_length=50)
+
+    def __str__(self):
+        return f"Perfil de {self.user.username}"
+

--- a/observatorio/templates/observatorio/base.html
+++ b/observatorio/templates/observatorio/base.html
@@ -22,29 +22,7 @@
 
   <body id="page-top">
     <!-- Navigation-->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
-      <div class="container px-4">
-        <a class="navbar-brand d-flex align-items-center" href="{% url 'home' %}">
-          <img src="{% static 'images/icono.png' %}" alt="Logo" height="30" class="me-2">
-          <span>SÍNTESIS ESTRATÉGICA</span>
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-          data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
-          aria-expanded="false" aria-label="Alternar navegación"><span class="navbar-toggler-icon"></span></button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-          <ul class="navbar-nav ms-auto">
-            <li class="nav-item"><a class="nav-link" href="{% url 'listar_informes' %}">Ver Informes</a></li>
-            <li class="nav-item"><a class="nav-link" href="{% url 'crear_informe' %}">Cargar Informe</a></li>
-            <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'suscribirse' %}">
-                Suscribirse
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+    {% include 'observatorio/navbar.html' %}
 
     <!-- Header de bienvenida -->
     <!-- Header de bienvenida -->

--- a/observatorio/templates/observatorio/buscar.html
+++ b/observatorio/templates/observatorio/buscar.html
@@ -15,7 +15,7 @@
         {% for informe in resultados %}
             <div class="list-group-item">
                 <h5 class="mb-1">
-                    <a href="{% url 'detalle_informe' informe.id %}">
+                    <a href="{% url 'detalle_informe' informe.id %}" target="_blank">
                         {{ informe.titulo }}
                     </a>
                 </h5>

--- a/observatorio/templates/observatorio/listar_informes.html
+++ b/observatorio/templates/observatorio/listar_informes.html
@@ -13,7 +13,7 @@
                     <span class="badge bg-secondary mb-2">{{ informe.categoria }}</span>
                     <p class="mb-1"><strong>Autor:</strong> {{ informe.autor }}</p>
                     <p class="mb-1">{{ informe.resumen }}</p>
-                    <a href="{% url 'detalle_informe' informe.id %}" class="btn btn-primary btn-sm mt-2">Ver informe</a>
+                    <a href="{% url 'detalle_informe' informe.id %}" target="_blank" class="btn btn-primary btn-sm mt-2">Ver informe</a>
                 </div>
             {% endfor %}
         </div>

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -1,0 +1,27 @@
+{% load static %}
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
+  <div class="container px-4">
+    <a class="navbar-brand d-flex align-items-center" href="{% url 'home' %}">
+      <img src="{% static 'images/icono.png' %}" alt="Logo" height="30" class="me-2">
+      <span>SÍNTESIS ESTRATÉGICA</span>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+      data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
+      aria-expanded="false" aria-label="Alternar navegación"><span class="navbar-toggler-icon"></span></button>
+    <div class="collapse navbar-collapse" id="navbarResponsive">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="{% url 'home' %}">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'quienes_somos' %}">¿Quiénes somos?</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'listar_informes' %}">Publicaciones</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
+        <li class="nav-item">
+          {% if user.is_authenticated %}
+            <a class="nav-link" href="{% url 'logout' %}">Salir</a>
+          {% else %}
+            <a class="nav-link" href="{% url 'login' %}">Ingresar</a>
+          {% endif %}
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/observatorio/templates/observatorio/quienes_somos.html
+++ b/observatorio/templates/observatorio/quienes_somos.html
@@ -1,0 +1,11 @@
+{% extends 'observatorio/base.html' %}
+
+{% block title %}¿Quiénes somos?{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+  <h2 class="text-center mb-4">Sobre el autor</h2>
+  <p class="lead">Este proyecto fue creado por Santiago Bonacci como parte de su aprendizaje en programación. 
+  Aquí compartimos análisis de consumos digitales y herramientas para comunicar mejor.</p>
+</div>
+{% endblock %}

--- a/observatorio/templates/registration/login.html
+++ b/observatorio/templates/registration/login.html
@@ -1,0 +1,17 @@
+{% extends 'observatorio/base.html' %}
+
+{% block title %}Ingresar{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 400px;">
+  <h2 class="text-center mb-4">Ingresar</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary w-100">Entrar</button>
+  </form>
+  <p class="mt-3 text-center">
+    ¿No tenés cuenta? <a href="{% url 'signup' %}">Registrate</a>
+  </p>
+</div>
+{% endblock %}

--- a/observatorio/templates/registration/signup.html
+++ b/observatorio/templates/registration/signup.html
@@ -1,0 +1,14 @@
+{% extends 'observatorio/base.html' %}
+
+{% block title %}Registrarse{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 500px;">
+  <h2 class="text-center mb-4">Crear cuenta</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-success w-100">Registrarse</button>
+  </form>
+</div>
+{% endblock %}

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.home, name='home'),
+    path('quienes-somos/', views.quienes_somos, name='quienes_somos'),
     path('crear/', views.InformeCreateView.as_view(), name='crear_informe'),
     path('informes/', views.InformeListView.as_view(), name='listar_informes'),
     path('buscar/', views.buscar_informes, name='buscar_informes'),

--- a/observatorio/views.py
+++ b/observatorio/views.py
@@ -11,8 +11,9 @@ from django.views.generic import (
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from .models import Informe, Categoria, ConsultaUsuario
-from .forms import InformeForm, SuscriptorForm
+from django.contrib.auth import login
+from .models import Informe, Categoria, ConsultaUsuario, PerfilUsuario
+from .forms import InformeForm, SuscriptorForm, CustomUserCreationForm
 from django.contrib import messages
 from django.db.models import Q
 
@@ -20,6 +21,27 @@ from django.db.models import Q
 def home(request):
     """Página inicial del sitio."""
     return render(request, 'observatorio/home.html')
+
+
+def quienes_somos(request):
+    """Muestra información sobre el autor del proyecto."""
+    return render(request, 'observatorio/quienes_somos.html')
+
+
+def signup(request):
+    """Registro de nuevos usuarios."""
+    if request.method == 'POST':
+        form = CustomUserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            PerfilUsuario.objects.create(
+                user=user, documento=form.cleaned_data['documento']
+            )
+            login(request, user)
+            return redirect('home')
+    else:
+        form = CustomUserCreationForm()
+    return render(request, 'registration/signup.html', {'form': form})
 
 class InformeCreateView(LoginRequiredMixin, CreateView):
     """Formulario para crear un nuevo informe."""


### PR DESCRIPTION
## Summary
- create reusable navbar.html and include it in base.html
- add about and signup views
- wire up auth URLs and templates for login and signup
- show "¿Quiénes somos?" page
- open reports in a new tab when listing or searching
- store extra user data with PerfilUsuario model

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840c5e9f42083239341e060957d34d1