### PR TITLE
Arregla mensajes de registro y cierre de sesión

### DIFF
--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 from .models import (
     Categoria,
     Informe,
@@ -63,6 +65,18 @@ class CustomUserCreationForm(UserCreationForm):
             "email",
             "documento",
         )
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get("password1")
+        password2 = self.cleaned_data.get("password2")
+
+        if password1 and password2 and password1 != password2:
+            raise ValidationError(self.error_messages["password_mismatch"], code="password_mismatch")
+        try:
+            validate_password(password2, self.instance)
+        except ValidationError:
+            raise ValidationError("Escribí una contraseña que cumpla con los parámetros.")
+        return password2
 
 
 class ComentarioForm(forms.ModelForm):

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -16,7 +16,7 @@
         <li class="nav-item"><a class="nav-link" href="{% url 'medios' %}">Medios</a></li>
         <li class="nav-item">
           {% if user.is_authenticated %}
-            <a class="nav-link" href="{% url 'logout' %}">Salir</a>
+            <a class="nav-link" href="{% url 'logout_user' %}">Salir</a>
           {% else %}
             <a class="nav-link" href="{% url 'login' %}">Ingresar</a>
           {% endif %}

--- a/observatorio/templates/registration/login.html
+++ b/observatorio/templates/registration/login.html
@@ -7,7 +7,18 @@
   <h2 class="text-center mb-4">Ingresar</h2>
   <form method="post">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% for field in form %}
+      <div class="mb-3">
+        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'class': 'form-control'}) }}
+        {% if field.help_text %}
+          <div class="form-text small">{{ field.help_text|safe }}</div>
+        {% endif %}
+        {% if field.errors %}
+          <div class="text-danger small">{{ field.errors|striptags }}</div>
+        {% endif %}
+      </div>
+    {% endfor %}
     <button type="submit" class="btn btn-primary w-100">Entrar</button>
   </form>
   <p class="mt-3 text-center">

--- a/observatorio/templates/registration/signup.html
+++ b/observatorio/templates/registration/signup.html
@@ -7,7 +7,18 @@
   <h2 class="text-center mb-4">Crear cuenta</h2>
   <form method="post">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% for field in form %}
+      <div class="mb-3">
+        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {{ field.as_widget(attrs={'class': 'form-control'}) }}
+        {% if field.help_text %}
+          <div class="form-text small">{{ field.help_text|safe }}</div>
+        {% endif %}
+        {% if field.errors %}
+          <div class="text-danger small">{{ field.errors|striptags }}</div>
+        {% endif %}
+      </div>
+    {% endfor %}
     <button type="submit" class="btn btn-success w-100">Registrarse</button>
   </form>
 </div>

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('buscar/', views.buscar_informes, name='buscar_informes'),
     path('medios/', views.MedioAmigoListView.as_view(), name='medios'),
     path('suscribirse/', views.suscribirse, name='suscribirse'),
+    path('logout/', views.logout_view, name='logout_user'),
     path('informe/<int:informe_id>/', views.InformeDetailView.as_view(), name='detalle_informe'),
     path('informe/<int:informe_id>/editar/', views.InformeUpdateView.as_view(), name='editar_informe'),
     path('informe/<int:informe_id>/eliminar/', views.InformeDeleteView.as_view(), name='eliminar_informe'),

--- a/observatorio/views.py
+++ b/observatorio/views.py
@@ -11,7 +11,7 @@ from django.views.generic import (
 )
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from django.contrib.auth import login
+from django.contrib.auth import login, logout
 from .models import (
     Informe,
     Categoria,
@@ -54,6 +54,12 @@ def signup(request):
     else:
         form = CustomUserCreationForm()
     return render(request, 'registration/signup.html', {'form': form})
+
+
+def logout_view(request):
+    """Cierra la sesión actual y redirige al inicio."""
+    logout(request)
+    return redirect('home')
 
 class InformeCreateView(LoginRequiredMixin, CreateView):
     """Formulario para crear un nuevo informe."""


### PR DESCRIPTION
## Resumen
- mejora el formulario de registro con estilos bootstrap
- muestra mensaje de error cuando la contraseña no cumple los requisitos
- se aplica mismo estilo al formulario de login
- agrega vista `logout_view` y ruta propia para cerrar sesión vía GET
- el enlace "Salir" ahora apunta a la nueva ruta

## Testing
- `python manage.py test` *(falla: no se pudo importar Django)*

------
https://chatgpt.com/codex/tasks/task_e_684181a279148323b83dfeff403b3605