### PR TITLE
Implement superuser controls and greeting

### DIFF
--- a/observatorio/templates/observatorio/detalle_informe.html
+++ b/observatorio/templates/observatorio/detalle_informe.html
@@ -15,6 +15,10 @@
             <p class="text-muted">Iniciá sesión para descargar el informe.</p>
         {% endif %}
     {% endif %}
+    {% if user.is_superuser %}
+        <a href="{% url 'editar_informe' informe.id %}" class="btn btn-warning me-2">Editar</a>
+        <a href="{% url 'eliminar_informe' informe.id %}" class="btn btn-danger">Eliminar</a>
+    {% endif %}
     <h4 class="mt-4">Comentarios</h4>
     {% if comentarios %}
         <ul class="list-group mb-3">

--- a/observatorio/templates/observatorio/listar_informes.html
+++ b/observatorio/templates/observatorio/listar_informes.html
@@ -4,6 +4,11 @@
 {% block content %}
   <div class="container my-5">
     <h2>Publicaciones</h2>
+    {% if user.is_superuser %}
+      <div class="mb-3">
+        <a href="{% url 'crear_informe' %}" class="btn btn-primary">Crear nuevo contenido</a>
+      </div>
+    {% endif %}
 
     {% if informes %}
       <div class="row row-cols-1 row-cols-md-2 g-4">

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -17,13 +17,14 @@
         <li class="nav-item"><a class="nav-link" href="{% url 'buscar_informes' %}">Buscar</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'medios' %}">Medios</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'suscribirse' %}">Newsletter</a></li>
-        <li class="nav-item">
-          {% if user.is_authenticated %}
-            <a class="nav-link" href="{% url 'logout_user' %}">Salir</a>
-          {% else %}
-            <a class="nav-link" href="{% url 'login' %}">Ingresar</a>
-          {% endif %}
-        </li>
+        {% if user.is_authenticated %}
+          <li class="nav-item d-flex align-items-center">
+            <span class="navbar-text text-white me-2">Hola, {{ user.username }}</span>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'logout_user' %}">Salir</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Ingresar</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>

--- a/observatorio/views.py
+++ b/observatorio/views.py
@@ -2,7 +2,7 @@
 
 from django.contrib import messages
 from django.contrib.auth import login, logout
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.db.models import Q
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
@@ -153,7 +153,7 @@ class InformeDetailView(DetailView):
         return redirect("detalle_informe", informe_id=self.object.id)
 
 
-class InformeUpdateView(LoginRequiredMixin, UpdateView):
+class InformeUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     """Actualiza un informe existente."""
 
     model = Informe
@@ -163,8 +163,11 @@ class InformeUpdateView(LoginRequiredMixin, UpdateView):
     login_url = "/accounts/login/"
     pk_url_kwarg = "informe_id"
 
+    def test_func(self):
+        return self.request.user.is_superuser
 
-class InformeDeleteView(LoginRequiredMixin, DeleteView):
+
+class InformeDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     """Elimina un informe."""
 
     model = Informe
@@ -172,6 +175,9 @@ class InformeDeleteView(LoginRequiredMixin, DeleteView):
     success_url = reverse_lazy("listar_informes")
     login_url = "/accounts/login/"
     pk_url_kwarg = "informe_id"
+
+    def test_func(self):
+        return self.request.user.is_superuser
 
 
 class MedioAmigoListView(ListView):


### PR DESCRIPTION
## Summary
- show a greeting with the logged username in the navbar
- allow only superusers to see the "Crear nuevo contenido" link
- add edit/delete options for superusers in the post detail
- enforce superuser check in update and delete views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684360d4e040832394f234e21ee9531e