### PR TITLE
Mejoras en cambio de contraseña

### DIFF
--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -73,7 +73,6 @@ class ConsultaUsuarioForm(forms.ModelForm):
 
 
 class CustomUserCreationForm(UserCreationForm):
-    documento = forms.CharField(max_length=50, label="Número de documento")
 
     class Meta(UserCreationForm.Meta):
         model = User
@@ -82,7 +81,6 @@ class CustomUserCreationForm(UserCreationForm):
             "first_name",
             "last_name",
             "email",
-            "documento",
         )
 
     def clean_password2(self):

--- a/observatorio/templates/registration/password_change_done.html
+++ b/observatorio/templates/registration/password_change_done.html
@@ -1,0 +1,10 @@
+{% extends 'observatorio/base.html' %}
+{% block content %}
+<div class="container mt-5">
+  <div class="card shadow p-4">
+    <h2 class="mb-4 text-success"><i class="bi bi-check-circle"></i> Contraseña cambiada</h2>
+    <p>Tu contraseña fue actualizada correctamente.</p>
+    <a href="{% url 'home' %}" class="btn btn-primary">Volver al inicio</a>
+  </div>
+</div>
+{% endblock %}

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.contrib.auth.views import PasswordChangeView
 from . import views
 
 urlpatterns = [
@@ -13,7 +12,6 @@ urlpatterns = [
     path("medios/", views.MedioAmigoListView.as_view(), name="medios"),
     path("suscribirse/", views.suscribirse, name="suscribirse"),
     path("logout/", views.logout_view, name="logout_user"),
-    path("cambiar-clave/", PasswordChangeView.as_view(template_name="registration/password_change_form.html"), name="password_change"),
     path(
         "informe/<int:informe_id>/",
         views.InformeDetailView.as_view(),


### PR DESCRIPTION
## Summary
- remove unused password change URL
- clean custom signup form
- add success template for password change

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844a07bdc64832389a9acc01bee5451