### PR TITLE
Add profile editing and custom password change

### DIFF
--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -4,7 +4,14 @@ from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
-from .models import Categoria, Comentario, ConsultaUsuario, Informe, Suscriptor
+from .models import (
+    Categoria,
+    Comentario,
+    ConsultaUsuario,
+    Informe,
+    PerfilUsuario,
+    Suscriptor,
+)
 
 
 class CategoriaForm(forms.ModelForm):
@@ -112,4 +119,22 @@ class ComentarioForm(forms.ModelForm):
                     "placeholder": "Escribí tu comentario aquí",
                 }
             )
+        }
+
+
+class PerfilUsuarioForm(forms.ModelForm):
+    class Meta:
+        model = PerfilUsuario
+        fields = ["biografia", "fecha_nacimiento"]
+        widgets = {
+            "biografia": forms.Textarea(
+                attrs={
+                    "class": "form-control",
+                    "rows": 4,
+                    "placeholder": "Contanos algo sobre vos",
+                }
+            ),
+            "fecha_nacimiento": forms.DateInput(
+                attrs={"class": "form-control", "type": "date"}
+            ),
         }

--- a/observatorio/templates/observatorio/cambiar_password.html
+++ b/observatorio/templates/observatorio/cambiar_password.html
@@ -1,0 +1,34 @@
+{% extends 'observatorio/base.html' %}
+{% load widget_tweaks %}
+{% block title %}Cambiar contraseña{% endblock %}
+{% block content %}
+<div class="container mt-5" style="max-width: 500px;">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2 class="mb-4 text-center"><i class="bi bi-key"></i> Cambiar contraseña</h2>
+      <form method="post">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div class="mb-3">
+          <label class="form-label" for="id_old_password">Contraseña actual</label>
+          {{ form.old_password|add_class:"form-control" }}
+          {{ form.old_password.errors }}
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="id_new_password1">Nueva contraseña</label>
+          {{ form.new_password1|add_class:"form-control" }}
+          {{ form.new_password1.errors }}
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="id_new_password2">Confirmar nueva contraseña</label>
+          {{ form.new_password2|add_class:"form-control" }}
+          {{ form.new_password2.errors }}
+        </div>
+        <button type="submit" class="btn btn-primary">
+          <i class="bi bi-save"></i> Cambiar
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/observatorio/templates/observatorio/editar_perfil.html
+++ b/observatorio/templates/observatorio/editar_perfil.html
@@ -1,0 +1,27 @@
+{% extends 'observatorio/base.html' %}
+{% load widget_tweaks %}
+{% block title %}Editar perfil{% endblock %}
+{% block content %}
+<div class="container mt-5" style="max-width: 600px;">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h2 class="mb-4 text-center">Editar perfil</h2>
+      <form method="post">
+        {% csrf_token %}
+        {% for field in form %}
+          <div class="mb-3">
+            <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field|add_class:"form-control" }}
+            {% if field.errors %}
+              <div class="text-danger small">{{ field.errors|striptags }}</div>
+            {% endif %}
+          </div>
+        {% endfor %}
+        <button type="submit" class="btn btn-primary">
+          <i class="bi bi-save"></i> Guardar cambios
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/observatorio/templates/observatorio/perfil.html
+++ b/observatorio/templates/observatorio/perfil.html
@@ -14,8 +14,11 @@
         <p><strong>Usuario:</strong> {{ usuario.username }}</p>
         <p><strong>Email:</strong> {{ usuario.email }}</p>
 
-        <a href="{% url 'password_change' %}" class="btn btn-outline-primary">
+        <a href="{% url 'mi_cambio_clave' %}" class="btn btn-outline-primary">
           <i class="bi bi-key"></i> Cambiar contraseña
+        </a>
+        <a href="{% url 'editar_perfil' %}" class="btn btn-outline-secondary ms-2">
+          <i class="bi bi-pencil"></i> Editar perfil
         </a>
       </div>
 

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -8,6 +8,12 @@ urlpatterns = [
     path("informes/", views.InformeListView.as_view(), name="listar_informes"),
     path("buscar/", views.buscar_informes, name="buscar_informes"),
     path("perfil/", views.ver_perfil, name="ver_perfil"),
+    path("perfil/editar/", views.editar_perfil, name="editar_perfil"),
+    path(
+        "perfil/cambiar-clave/",
+        views.CambioPasswordView.as_view(),
+        name="mi_cambio_clave",
+    ),
     path("consulta-ia/", views.consulta_ia, name="consulta_ia"),
     path("medios/", views.MedioAmigoListView.as_view(), name="medios"),
     path("suscribirse/", views.suscribirse, name="suscribirse"),


### PR DESCRIPTION
## Summary
- add new form `PerfilUsuarioForm`
- allow users to edit biography and birth date
- create custom PasswordChangeView with Bootstrap template
- link profile page with edit and password change

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844a6135bd083239952f49a492337d8