### PR TITLE
Agregar carga de notas en Medios

### DIFF
--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -9,6 +9,7 @@ from .models import (
     Comentario,
     ConsultaUsuario,
     Informe,
+    MedioAmigo,
     PerfilUsuario,
     Suscriptor,
 )
@@ -47,6 +48,18 @@ class InformeForm(forms.ModelForm):
                 attrs={"class": "form-control", "placeholder": "Autor/a del informe"}
             ),
             "pdf": forms.ClearableFileInput(attrs={"class": "form-control"}),
+        }
+
+
+class MedioAmigoForm(forms.ModelForm):
+    class Meta:
+        model = MedioAmigo
+        fields = ["titulo", "autor", "fecha", "enlace"]
+        widgets = {
+            "titulo": forms.TextInput(attrs={"class": "form-control", "placeholder": "Título"}),
+            "autor": forms.TextInput(attrs={"class": "form-control", "placeholder": "Autor"}),
+            "fecha": forms.DateInput(attrs={"class": "form-control", "type": "date"}),
+            "enlace": forms.URLInput(attrs={"class": "form-control", "placeholder": "URL"}),
         }
 
 

--- a/observatorio/migrations/0009_medioamigo_add_fields.py
+++ b/observatorio/migrations/0009_medioamigo_add_fields.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('observatorio', '0008_remove_perfilusuario_documento_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='medioamigo',
+            name='autor',
+            field=models.CharField(default='', max_length=100),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='medioamigo',
+            name='fecha',
+            field=models.DateField(default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+    ]

--- a/observatorio/models.py
+++ b/observatorio/models.py
@@ -81,6 +81,8 @@ class MedioAmigo(models.Model):
     """Enlaces o resúmenes de medios externos."""
 
     titulo = models.CharField(max_length=200)
+    autor = models.CharField(max_length=100)
+    fecha = models.DateField()
     enlace = models.URLField()
     resumen = models.TextField(blank=True)
 

--- a/observatorio/templates/observatorio/crear_medio.html
+++ b/observatorio/templates/observatorio/crear_medio.html
@@ -1,0 +1,32 @@
+{% extends 'observatorio/base.html' %}
+
+{% block title %}Cargar nota de medio{% endblock %}
+
+{% block content %}
+  <div class="container mt-5">
+    <div class="mb-4 text-center">
+      <h2 class="section-title">Cargar nueva nota de medio</h2>
+      <p class="text-muted">Solo los administradores pueden agregar estas notas.</p>
+    </div>
+
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <form method="post">
+          {% csrf_token %}
+          {% for field in form %}
+            <div class="mb-3">
+              <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+              {{ field }}
+              {% if field.errors %}
+                <div class="text-danger small">{{ field.errors|striptags }}</div>
+              {% endif %}
+            </div>
+          {% endfor %}
+          <button type="submit" class="btn btn-primary">
+            <i class="bi bi-upload"></i> Guardar
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/observatorio/templates/observatorio/medios.html
+++ b/observatorio/templates/observatorio/medios.html
@@ -11,6 +11,14 @@
     Creemos en el valor del intercambio, la colaboración y la construcción colectiva de conocimiento.
   </p>
 
+  {% if user.is_superuser %}
+    <div class="mb-3 text-end">
+      <a href="{% url 'crear_medio' %}" class="btn btn-primary">
+        <i class="bi bi-plus-lg"></i> Cargar nueva nota
+      </a>
+    </div>
+  {% endif %}
+
   {% if medios %}
     <div class="row">
       {% for medio in medios %}
@@ -22,9 +30,10 @@
                   {{ medio.titulo }}
                 </a>
               </h5>
-              {% if medio.resumen %}
-                <p class="card-text text-muted">{{ medio.resumen }}</p>
-              {% endif %}
+              <p class="text-muted mb-1">{{ medio.autor }} - {{ medio.fecha }}</p>
+              <div class="ratio ratio-16x9">
+                <iframe src="{{ medio.enlace }}" title="{{ medio.titulo }}" allowfullscreen></iframe>
+              </div>
             </div>
           </div>
         </div>

--- a/observatorio/urls.py
+++ b/observatorio/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     ),
     path("consulta-ia/", views.consulta_ia, name="consulta_ia"),
     path("medios/", views.MedioAmigoListView.as_view(), name="medios"),
+    path("medios/cargar/", views.MedioAmigoCreateView.as_view(), name="crear_medio"),
     path("suscribirse/", views.suscribirse, name="suscribirse"),
     path("logout/", views.logout_view, name="logout_user"),
     path(

--- a/observatorio/views.py
+++ b/observatorio/views.py
@@ -23,6 +23,7 @@ from .forms import (
     ComentarioForm,
     CustomUserCreationForm,
     InformeForm,
+    MedioAmigoForm,
     PerfilUsuarioForm,
     SuscriptorForm,
 )
@@ -235,6 +236,23 @@ class MedioAmigoListView(ListView):
     model = MedioAmigo
     template_name = "observatorio/medios.html"
     context_object_name = "medios"
+
+
+class MedioAmigoCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+    """Carga de una nueva nota de medios externos."""
+
+    model = MedioAmigo
+    form_class = MedioAmigoForm
+    template_name = "observatorio/crear_medio.html"
+    success_url = reverse_lazy("medios")
+    login_url = "/accounts/login/"
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def form_valid(self, form):
+        messages.success(self.request, "✅ Nota guardada con éxito.")
+        return super().form_valid(form)
 
 
 def consulta_ia(request):


### PR DESCRIPTION
## Summary
- permitir que solo los administradores carguen notas
- crear formulario `MedioAmigoForm`
- añadir vista `MedioAmigoCreateView`
- exponer URL `medios/cargar/`
- mostrar botón de carga en la lista para superusuarios
- incluir nueva plantilla `crear_medio.html`
- actualizar modelo `MedioAmigo` y migraciones

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844ab7877748323ae5c2399b0ad362f