### PR TITLE
Remove decorative emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este es un proyecto desarrollado en el marco del curso **Python Flex de Coderhou
 
 ---
 
-## 📌 Descripción del proyecto
+## Descripción del proyecto
 
 Se trata de un portal institucional en desarrollo, orientado al análisis de datos de consumo. Se propone como una plataforma profesional para publicar informes, organizar información y ofrecer contenido útil a los usuarios.
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -10848,8 +10848,4 @@ section {
   align-items: center;
 }
 
-.section-title::before {
-  content: "\1F4CC" " ";
-  /* emoji 📌 before each title */
-}
 


### PR DESCRIPTION
## Summary
- remove emoji from README heading
- remove decorative emoji from page titles

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844b1191e3883238ebc8dc4bfc9d788