### PR TITLE
Implement newsletter submenu and informes enhancements

### DIFF
--- a/SintesisEstrategica/settings.py
+++ b/SintesisEstrategica/settings.py
@@ -114,7 +114,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "es-ar"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/Argentina/Buenos_Aires"
 
 USE_I18N = True
 
@@ -130,6 +130,9 @@ STATICFILES_DIRS = [
 
 STATIC_URL = "static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+
+MEDIA_URL = "media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/SintesisEstrategica/urls.py
+++ b/SintesisEstrategica/urls.py
@@ -17,6 +17,8 @@ Incluir otra configuración de URLs
 
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
+from django.conf.urls.static import static
 
 from observatorio import views as observatorio_views
 
@@ -26,3 +28,6 @@ urlpatterns = [
     path("accounts/signup/", observatorio_views.signup, name="signup"),
     path("", include("observatorio.urls")),  # Rutas de la App
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/observatorio/forms.py
+++ b/observatorio/forms.py
@@ -16,10 +16,21 @@ from .models import (
 class InformeForm(forms.ModelForm):
     class Meta:
         model = Informe
-        fields = ["titulo", "resumen", "contenido", "categoria", "autor", "pdf"]
+        fields = [
+            "titulo",
+            "resumen",
+            "palabras_clave",
+            "contenido",
+            "categoria",
+            "autor",
+            "pdf",
+        ]
         widgets = {
             "titulo": forms.TextInput(attrs={"class": "form-control", "placeholder": "Título del informe"}),
             "resumen": forms.Textarea(attrs={"class": "form-control", "placeholder": "Resumen del contenido", "rows": 3}),
+            "palabras_clave": forms.TextInput(
+                attrs={"class": "form-control", "placeholder": "Palabras clave"}
+            ),
             "contenido": forms.Textarea(attrs={"class": "form-control", "placeholder": "Texto completo del informe", "rows": 8}),
             "categoria": forms.Select(attrs={"class": "form-select"}),
             "autor": forms.TextInput(attrs={"class": "form-control", "placeholder": "Autor/a del informe"}),

--- a/observatorio/migrations/0003_informe_palabras_clave_fecha.py
+++ b/observatorio/migrations/0003_informe_palabras_clave_fecha.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('observatorio', '0002_medioamigo_medio'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='informe',
+            name='palabras_clave',
+            field=models.CharField(max_length=200, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='informe',
+            name='fecha',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+    ]

--- a/observatorio/models.py
+++ b/observatorio/models.py
@@ -20,10 +20,11 @@ class Informe(models.Model):
     titulo = models.CharField(max_length=200, db_index=True)
     autor = models.CharField(max_length=100, db_index=True)
     resumen = models.TextField(db_index=True)
+    palabras_clave = models.CharField(max_length=200, blank=True)
     contenido = models.TextField()
     pdf = models.FileField(upload_to="informes_pdf/", blank=True, null=True)
     categoria = models.ForeignKey(Categoria, on_delete=models.CASCADE)
-    fecha = models.DateField(auto_now_add=True)
+    fecha = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         ordering = ["-fecha"]

--- a/observatorio/templates/observatorio/detalle_informe.html
+++ b/observatorio/templates/observatorio/detalle_informe.html
@@ -4,10 +4,13 @@
 <div class="container my-5">
     <h2 class="section-title">{{ informe.titulo }}</h2>
     <p><strong>Autor:</strong> {{ informe.autor }}</p>
-    <p><strong>Fecha:</strong> {{ informe.fecha }}</p>
+    <p><strong>Fecha:</strong> {{ informe.fecha|date:"d/m/Y H:i" }}</p>
     <p><strong>Categoría:</strong> {{ informe.categoria }}</p>
     <hr>
-    <p>{{ informe.contenido }}</p>
+    <p>{{ informe.resumen }}</p>
+    {% if informe.palabras_clave %}
+        <p><strong>Palabras clave:</strong> {{ informe.palabras_clave }}</p>
+    {% endif %}
     {% if informe.pdf %}
         {% if user.is_authenticated %}
             <a href="{{ informe.pdf.url }}" class="btn btn-outline-primary mb-3" download>Descargar informe</a>

--- a/observatorio/templates/observatorio/listar_informes.html
+++ b/observatorio/templates/observatorio/listar_informes.html
@@ -19,6 +19,9 @@
                 <h5 class="card-title">{{ informe.titulo }}</h5>
                 <p class="mb-1"><strong>Autor:</strong> {{ informe.autor }}</p>
                 <p class="card-text text-muted">{{ informe.resumen|truncatewords:30 }}</p>
+                {% if informe.palabras_clave %}
+                <p class="small text-muted">🔖 {{ informe.palabras_clave }}</p>
+                {% endif %}
                 <span class="badge bg-secondary">{{ informe.categoria }}</span>
               </div>
               <div class="card-footer d-flex justify-content-between align-items-center">

--- a/observatorio/templates/observatorio/medios.html
+++ b/observatorio/templates/observatorio/medios.html
@@ -27,11 +27,13 @@
         <div class="card shadow-sm h-100 border-0">
           <div class="card-body d-flex flex-column">
             <h5 class="card-title">{{ medio.titulo }}</h5>
-            <p class="text-muted mb-2">{{ medio.autor }} — {{ medio.fecha|date:"d/m/Y" }}</p>
+            <p class="mb-1"><i class="bi bi-person"></i> {{ medio.autor }}</p>
+            <p class="mb-1"><i class="bi bi-newspaper"></i> {{ medio.medio }}</p>
+            <p class="text-muted">{{ medio.fecha|date:"d/m/Y" }}</p>
 
             <div class="mt-auto d-flex justify-content-between align-items-center">
               <a href="{{ medio.enlace }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
-                <i class="bi bi-box-arrow-up-right"></i> Ver nota completa
+                <i class="bi bi-box-arrow-up-right"></i> Leer nota completa
               </a>
 
               {% if user.is_superuser %}

--- a/observatorio/templates/observatorio/navbar.html
+++ b/observatorio/templates/observatorio/navbar.html
@@ -22,9 +22,9 @@
             <li><a class="dropdown-item" href="{% url 'consulta_ia' %}">Consulta nuestra IA</a></li>
             <li><a class="dropdown-item" href="{% url 'medios' %}">Medios</a></li>
             <li><a class="dropdown-item" href="{% url 'buscar_informes' %}">Buscar</a></li>
+            <li><a class="dropdown-item" href="{% url 'suscribirse' %}">Newsletter</a></li>
           </ul>
         </li>
-        <li class="nav-item"><a class="nav-link" href="{% url 'suscribirse' %}">Newsletter</a></li>
         {% if user.is_authenticated %}
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="perfilDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
## Summary
- move newsletter under Services dropdown
- show medium name and better layout for external articles
- allow keywords and timestamp on informes
- display keywords in listing and detail views
- configure Argentina timezone and media handling

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6845ae5f3edc832395df8751e46c428b