### PR TITLE
Mejoras menores y documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ seguro:
 - `SECRET_KEY`: clave secreta de Django.
 - `DJANGO_DEBUG`: establecé `False` para desactivar el modo debug.
 - `ALLOWED_HOSTS`: lista de hosts permitidos separada por espacios.
+- `OPENAI_API_KEY`: necesaria para usar la sección de consulta a la IA.
 
 Si no se definen, se usarán valores por defecto pensados para desarrollo.
+En particular, si omitís `OPENAI_API_KEY` la función de consultas a la IA
+permanecerá inactiva.
 
 ---
 

--- a/docs/ANALISIS.md
+++ b/docs/ANALISIS.md
@@ -1,0 +1,23 @@
+# Análisis del proyecto
+
+Este documento resume las principales características del portal **Síntesis Estratégica** y los ajustes realizados para mantener el código ordenado.
+
+## Funcionalidades
+
+- Gestión de informes con carga, edición y eliminación.
+- Búsqueda de informes por título, autor o resumen.
+- Suscripción de usuarios mediante formulario validado.
+- Consultas a un modelo de IA (opcional, requiere `OPENAI_API_KEY`).
+- Administración sencilla de datos desde el panel de Django.
+
+## Ajustes aplicados
+
+- Se registraron todos los modelos en `admin.py` para facilitar la administración.
+- Se añadieron pruebas unitarias que validan la lista y el detalle de informes.
+- Se aclaró en el README el uso de la variable `OPENAI_API_KEY`.
+
+Para ejecutar las pruebas una vez instaladas las dependencias:
+
+```bash
+python manage.py test
+```

--- a/observatorio/admin.py
+++ b/observatorio/admin.py
@@ -1,8 +1,19 @@
 from django.contrib import admin
 
-from .models import Categoria, ConsultaUsuario, Informe, Suscriptor
+from .models import (
+    Categoria,
+    Comentario,
+    ConsultaUsuario,
+    Informe,
+    MedioAmigo,
+    PerfilUsuario,
+    Suscriptor,
+)
 
 admin.site.register(Categoria)
 admin.site.register(Informe)
 admin.site.register(ConsultaUsuario)
 admin.site.register(Suscriptor)
+admin.site.register(PerfilUsuario)
+admin.site.register(Comentario)
+admin.site.register(MedioAmigo)

--- a/observatorio/tests.py
+++ b/observatorio/tests.py
@@ -21,3 +21,38 @@ class InformeModelTests(TestCase):
             categoria=categoria,
         )
         self.assertEqual(str(informe), "Informe de prueba")
+
+
+class InformeListViewTests(TestCase):
+    def setUp(self):
+        categoria = Categoria.objects.create(nombre="Demo", descripcion="Cat")
+        Informe.objects.create(
+            titulo="Ejemplo",
+            autor="Autor",
+            resumen="Resumen",
+            contenido="Contenido",
+            categoria=categoria,
+        )
+
+    def test_list_view_status_code(self):
+        response = self.client.get(reverse("listar_informes"))
+        self.assertEqual(response.status_code, 200)
+
+
+class InformeDetailViewTests(TestCase):
+    def setUp(self):
+        categoria = Categoria.objects.create(nombre="Demo", descripcion="Cat")
+        self.informe = Informe.objects.create(
+            titulo="Ejemplo",
+            autor="Autor",
+            resumen="Resumen",
+            contenido="Contenido",
+            categoria=categoria,
+        )
+
+    def test_detail_view_status_code(self):
+        response = self.client.get(
+            reverse("detalle_informe", kwargs={"informe_id": self.informe.id})
+        )
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
## Summary
- registrar todos los modelos en `admin.py`
- añadir tests para vistas de informes
- explicar variable `OPENAI_API_KEY` en README
- agregar documento de análisis del proyecto

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684776339184832395e4f7624c53764a